### PR TITLE
Use DMI matching for conflicting SSID 0x1f660101 between Ayaneo and AYN

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -20,6 +20,7 @@
 #include <linux/input.h>
 #include <linux/leds.h>
 #include <linux/ctype.h>
+#include <linux/dmi.h>
 #include <sound/core.h>
 #include <sound/jack.h>
 #include <sound/hda_codec.h>
@@ -7285,8 +7286,8 @@ enum {
 	ALC269_FIXUP_DELL4_MIC_NO_PRESENCE,
 	ALC269_FIXUP_DELL4_MIC_NO_PRESENCE_QUIET,
 	ALC269_FIXUP_HEADSET_MODE,
-	ALC269_FIXUP_HEADSET_AYA_2,
-	ALC269_FIXUP_HEADSET_AYA_GEEK,
+ 	ALC269_FIXUP_DMI_MATCH,
+	ALC269_FIXUP_AYA_HEADSET_VOLUME,
 	ALC269_FIXUP_HEADSET_MODE_NO_HP_MIC,
 	ALC269_FIXUP_ASPIRE_HEADSET_MIC,
 	ALC269_FIXUP_ASUS_X101_FUNC,
@@ -7533,6 +7534,30 @@ enum {
 	ALC285_FIXUP_ASUS_GU605_SPI_SPEAKER2_TO_DAC1,
 	ALC287_FIXUP_LENOVO_THKPAD_WH_ALC1318,
 };
+
+/* A special fixup for AYN and AYANEO handhelds as both
+*  have the same PCI SSID as well as the same codec, but
+*  require different quirks, falling back to DMI matching.
+*/
+static void alc269_fixup_match_via_dmi(struct hda_codec *codec,
+                                        const struct hda_fixup *fix, int action)
+{
+	int alc269_fix_id;
+	const char *board_name = dmi_get_system_info(DMI_BOARD_NAME);
+
+	if (dmi_name_in_vendors("AYANEO") || dmi_name_in_vendors("AYADEVICE") || dmi_name_in_vendors("AYA DEVICE")) {
+		if (board_name && (strcmp(board_name, "AYANEO 2") || strcmp(board_name, "AYANEO 2S") || strcmp(board_name, "GEEK") || strcmp(board_name, "GEEK 1S"))) {
+			alc269_fix_id = ALC269_FIXUP_AYA_HEADSET_VOLUME;
+		} else {
+			return;
+		}	
+	} else if (dmi_name_in_vendors("ayn") && strcmp(board_name, "Loki MiniPro")) {
+		alc269_fix_id = ALC269VB_FIXUP_AYANEO_SPKR_PIN_FIX;
+	} else {
+		return;
+	}
+	__snd_hda_apply_fixup(codec, alc269_fix_id, action, 0);
+}
 
 /* A special fixup for Lenovo C940 and Yoga Duet 7;
  * both have the very same PCI SSID, and we need to apply different fixups
@@ -8802,11 +8827,11 @@ static const struct hda_fixup alc269_fixups[] = {
 		.chained = true,
 		.chain_id = ALC256_FIXUP_ASUS_HEADSET_MODE
 	},
-	[ALC269_FIXUP_HEADSET_AYA_2] = {
+	[ALC269_FIXUP_DMI_MATCH] = {
 		.type = HDA_FIXUP_FUNC,
-		.v.func = alc269_fixup_headphone_volume,
+		.v.func = alc269_fixup_match_via_dmi,
 	},
-	[ALC269_FIXUP_HEADSET_AYA_GEEK] = {
+	[ALC269_FIXUP_AYA_HEADSET_VOLUME] = {
 		.type = HDA_FIXUP_FUNC,
 		.v.func = alc269_fixup_headphone_volume,
 	},
@@ -10637,8 +10662,7 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
 	SND_PCI_QUIRK(0x1d72, 0x1947, "RedmiBook Air", ALC255_FIXUP_XIAOMI_HEADSET_MIC),
 	SND_PCI_QUIRK(0x2782, 0x0232, "CHUWI CoreBook XPro", ALC269VB_FIXUP_CHUWI_COREBOOK_XPRO),
 	SND_PCI_QUIRK(0x2782, 0x1707, "Vaio VJFE-ADL", ALC298_FIXUP_SPK_VOLUME),
-	SND_PCI_QUIRK(0x1f66, 0x0101, "AYANEO 2", ALC269_FIXUP_HEADSET_AYA_2),
-	SND_PCI_QUIRK(0x1f66, 0x0101, "GEEK", ALC269_FIXUP_HEADSET_AYA_GEEK),
+	SND_PCI_QUIRK(0x1f66, 0x0101, "Multiple Vendors", ALC269_FIXUP_DMI_MATCH),
 	SND_PCI_QUIRK(0x1f66, 0x0103, "AYANEO AIR 1S", ALC269VB_FIXUP_AYANEO_SPKR_PIN_FIX),
 	SND_PCI_QUIRK(0x8086, 0x2074, "Intel NUC 8", ALC233_FIXUP_INTEL_NUC8_DMIC),
 	SND_PCI_QUIRK(0x8086, 0x2080, "Intel NUC 8 Rugged", ALC256_FIXUP_INTEL_NUC8_RUGGED),


### PR DESCRIPTION
This is after Fewt submitted a patch that appears to apply for all 0x1660103 devices, Previous PR is no longer required for that SSID.